### PR TITLE
Add reflect-config.json for Monix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,6 @@ lazy val root = (project in file("."))
     nativeImageOptions ++= Seq(
       "--no-fallback",
       "--allow-incomplete-classpath",
-      "--initialize-at-run-time=monix.execution.internal.jctools,org.jctools"
+      "--initialize-at-run-time=org.jctools"
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 import Dependencies._
 
-ThisBuild / scalaVersion     := "2.13.4"
-ThisBuild / version          := "0.1.0-SNAPSHOT"
-ThisBuild / organization     := "com.example"
+ThisBuild / scalaVersion := "2.13.4"
+ThisBuild / version := "0.1.0-SNAPSHOT"
+ThisBuild / organization := "com.example"
 ThisBuild / organizationName := "example"
 
 lazy val root = (project in file("."))
@@ -12,5 +12,9 @@ lazy val root = (project in file("."))
     Compile / mainClass := Some("example.MonixHello"),
     libraryDependencies += scalaTest % Test,
     libraryDependencies += "io.monix" %% "monix" % "3.2.2",
-    nativeImageOptions ++= Seq("--no-fallback","--initialize-at-run-time=monix.execution.internal.jctools"),
+    nativeImageOptions ++= Seq(
+      "--no-fallback",
+      "--allow-incomplete-classpath",
+      "--initialize-at-run-time=monix.execution.internal.jctools,org.jctools"
+    )
   )

--- a/src/main/resources/META-INF/native-image/example/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/example/reflect-config.json
@@ -1,0 +1,178 @@
+[
+    {
+        "name": "monix.execution.internal.atomic.LeftRight128Java8BoxedObjectImpl",
+        "fields": [
+            {
+                "name": "value",
+                "allowUnsafeAccess": true
+            }
+        ]
+    },
+    {
+        "name": "monix.execution.internal.atomic.LeftRight256Java8BoxedIntImpl",
+        "fields": [
+            {
+                "name": "value",
+                "allowUnsafeAccess": true
+            }
+        ]
+    },
+    {
+        "name": "monix.execution.internal.atomic.NormalJava8BoxedInt",
+        "fields": [
+            {
+                "name": "value",
+                "allowUnsafeAccess": true
+            }
+        ]
+    },
+    {
+        "name": "monix.execution.internal.atomic.NormalJava8BoxedObject",
+        "fields": [
+            {
+                "name": "value",
+                "allowUnsafeAccess": true
+            }
+        ]
+    },
+    {
+        "name": "org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields",
+        "fields": [
+            {
+                "name": "producerLimit",
+                "allowUnsafeAccess": true
+            }
+        ]
+    },
+    {
+        "name": "org.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields",
+        "fields": [
+            {
+                "name": "consumerIndex",
+                "allowUnsafeAccess": true
+            }
+        ]
+    },
+    {
+        "name": "org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields",
+        "fields": [
+            {
+                "name": "producerIndex",
+                "allowUnsafeAccess": true
+            }
+        ]
+    },
+    {
+        "name": "org.jctools.queues.BaseSpscLinkedArrayQueueConsumerField",
+        "fields": [
+            {
+                "name": "consumerIndex",
+                "allowUnsafeAccess": true
+            }
+        ]
+    },
+    {
+        "name": "org.jctools.queues.BaseSpscLinkedArrayQueueProducerFields",
+        "fields": [
+            {
+                "name": "producerIndex",
+                "allowUnsafeAccess": true
+            }
+        ]
+    },
+    {
+        "name": "org.jctools.queues.MpmcArrayQueueConsumerIndexField",
+        "fields": [
+            {
+                "name": "consumerIndex",
+                "allowUnsafeAccess": true
+            }
+        ]
+    },
+    {
+        "name": "org.jctools.queues.MpmcArrayQueueProducerIndexField",
+        "fields": [
+            {
+                "name": "producerIndex",
+                "allowUnsafeAccess": true
+            }
+        ]
+    },
+    {
+        "name": "scala.concurrent.BlockContext$",
+        "allDeclaredMethods": true
+    },
+    {
+        "name": "jdk.internal.misc.Unsafe",
+        "methods": [
+            {
+                "name": "getUnsafe",
+                "parameterTypes": []
+            }
+        ]
+    },
+    {
+        "name": "sun.misc.Unsafe",
+        "fields": [
+            {
+                "name": "theUnsafe"
+            }
+        ],
+        "methods": [
+            {
+                "name": "copyMemory",
+                "parameterTypes": [
+                    "java.lang.Object",
+                    "long",
+                    "java.lang.Object",
+                    "long",
+                    "long"
+                ]
+            },
+            {
+                "name": "copyMemory",
+                "parameterTypes": [
+                    "java.lang.Object",
+                    "long",
+                    "java.lang.Object",
+                    "long",
+                    "long"
+                ]
+            },
+            {
+                "name": "fullFence",
+                "parameterTypes": []
+            },
+            {
+                "name": "getAndAddInt",
+                "parameterTypes": [
+                    "java.lang.Object",
+                    "long",
+                    "int"
+                ]
+            },
+            {
+                "name": "getAndAddLong",
+                "parameterTypes": [
+                    "java.lang.Object",
+                    "long",
+                    "long"
+                ]
+            },
+            {
+                "name": "getAndSetObject",
+                "parameterTypes": [
+                    "java.lang.Object",
+                    "long",
+                    "java.lang.Object"
+                ]
+            },
+            {
+                "name": "invokeCleaner",
+                "parameterTypes": [
+                    "java.nio.ByteBuffer"
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
- Reflect configuration is needed for Monix to run successfully
- You can usually get this configuration using GraalVM's built-in reflection agent that prints it for you (though it's verbose)
- Formatting changes in this PR are caused by Scalafmt, sorry